### PR TITLE
Or sidebar

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -22,4 +22,3 @@ sidebar:
 product-family:
   name: BlueXP
   repo: bluexp-family
-  sidebar_label: All BlueXP documentation


### PR DESCRIPTION
removing sidebar_label keyword from project yml file 

the sidebar_label keyword, is now obsolete and must be removed from project files before the end of 2023. 